### PR TITLE
Make sure units argument is passed through on form submit

### DIFF
--- a/pwpusher_private/interface.php
+++ b/pwpusher_private/interface.php
@@ -182,7 +182,7 @@ function getFormElements()
                       $expirationTimeDefault . 
                       '" name="time" aria-label="time" />
                   <div class="input-group-btn">
-                    <select class="form-control">
+                    <select class="form-control" name="units">
                       <option>' . translate('minutes') . '</option>
                       <option>' . translate('hours') . '</option>
                       <option>' . translate('days') . '</option>


### PR DESCRIPTION
When I upgraded my installation today I noticed that the units option wasn't being respected when secrets were being created (it would always use minutes, and not convert to hours/days if selected). This change fixes the issue.