### PR TITLE
IP Whitelist Check for Creating Credentials

### DIFF
--- a/pwpusher_private/config.php
+++ b/pwpusher_private/config.php
@@ -47,6 +47,13 @@
     //Maximum life of a shared credential/password (in minutes).
     $credMaxLife = (60 * 24 * 90); //90 days
 
+    //IP Whitelist for creating credentials
+    //Whitelist is an array of CIDR notation IP addresses
+    $checkCreatorIpWhitelist = true;
+    $creatorIpWhitelist = array(
+        "10.20.0.0/16"
+    );
+
     
 //Email:
     

--- a/pwpusher_private/security.php
+++ b/pwpusher_private/security.php
@@ -121,3 +121,32 @@ function getSalt()
     $salt = substr(str_replace('+', '.', base64_encode(pack('N4', mt_rand(), mt_rand(), mt_rand(), mt_rand()))), 0, 22);
     return $salt;
 }
+
+/**
+ * Check if the client if an ip is in array of supplied CIDR notation IP ranges
+ *
+ * @return bool $validIp
+ */
+function ipInList($ipString, $cidrArray)
+{
+    $validIp = false;
+    $ipLong = ip2long($ipString);
+    foreach ($cidrArray as $cidr)
+        {
+            try
+            {
+                list ($ipWhite, $cidrNum) = explode('/', $cidr);
+                $ipWhiteLong = ip2long($ipWhite);
+                $netmask = -1 << (32 - (int)$cidrNum);
+                if (($ipLong & $netmask) == ($ipWhiteLong & $netmask))
+                {
+                    $validIp = true;
+                }
+            }
+            catch (Error $error)
+            {
+
+            }
+        }
+    return $validIp;
+}

--- a/pwpusher_public/pw.php
+++ b/pwpusher_public/pw.php
@@ -50,7 +50,7 @@ if ($requireCASAuth) {
 }
 
 //If the form function argument doesn't exist, print the form for the user.
-if ($arguments['func'] == 'none' || $arguments == false) {
+if ($arguments['func'] == 'none' || $arguments == false && $creatorIpOk) {
 
     //Force CAS Authentication in order to load the form
     if ($requireCASAuth) {
@@ -77,7 +77,7 @@ if ($arguments['func'] == 'none' || $arguments == false) {
     //Get form elements
     print getFormElements();
 
-} elseif ($arguments['func'] == 'post') {
+} elseif ($arguments['func'] == 'post' && $creatorIpOk) {
 
     //Force CAS Authentication in order to post the form
     if ($requireCASAuth) {

--- a/pwpusher_public/pw.php
+++ b/pwpusher_public/pw.php
@@ -13,12 +13,25 @@ require '../pwpusher_private/input.php';
 require '../pwpusher_private/interface.php';
 require '../pwpusher_private/CAS/CAS.php';
 
+// check if we need to check for white listing
+$creatorIpOk = !$checkCreatorIpWhitelist;
+if ($checkCreatorIpWhitelist)
+{
+    $creatorIpOk = false;
+    $ipClientString = $_SERVER['REMOTE_ADDR'];
+    $creatorIpOk = ipInList($ipClientString, $creatorIpWhitelist);
+}
+
 //Print the header
 print getHeader();
 
 //Print the navbar
 /** @noinspection PhpToStringImplementationInspection */
-print getNavBar();
+if ($creatorIpOk)
+{
+    print getNavBar();
+}
+
 
 //Find user arguments, if any.
 $arguments = getArguments();


### PR DESCRIPTION
Dear Benjamin,
I have added a whitelist functionality for creating credentials. It is an additional (optional) layer of security and also allows a simple method of authentication (without logging in) by limiting creation of credentials to specific IP addresses.
The summary of additions are as follows:
config.php:
- added a boolean flag to check against whitelist and added a whitelist array for CIDR IP ranges
security.php:
- added a function to check an IP address against an array CIDR ranges
pw.php:
- added a check of client IP against whitelist if the whitelist flag is set
- navbar is now only displayed to whitelisted IP addresses
- null URL argument branch of the code is now only available to whitelisted IP addresses
- post URL argument branch of the code is now only available to whitelisted IP addresses